### PR TITLE
Add automatic dark theme support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A modern, responsive marketing site for Obod Soft built with Next.js. The projec
 - Modern and responsive design with Next.js and React
 - Smooth animations and transitions
 - Mobile-friendly navigation
+- Automatic light and dark theme based on user preferences
 - Contact form with email functionality
 - Dedicated pages for services, about, portfolio, and contact
 - Engaging marketing copy on each page to convert visitors

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,9 +11,63 @@
 
 @media (prefers-color-scheme: dark) {
     :root {
-        --text-color: #f8f9fa;
+        --text-color: #f1f3f5;
         --light-color: #212529;
-        --dark-color: #f8f9fa;
+        --dark-color: #f1f3f5;
+    }
+
+    html {
+        color-scheme: dark;
+    }
+
+    body {
+        color: var(--text-color);
+        background-color: var(--light-color);
+    }
+
+    header {
+        background-color: rgba(33,37,41,0.95);
+    }
+
+    header.scrolled {
+        background-color: var(--light-color);
+    }
+
+    .hero,
+    .page-hero {
+        background: linear-gradient(135deg,#343a40 0%,#212529 100%);
+    }
+
+    .services,
+    .service-card,
+    .about,
+    .portfolio,
+    .contact {
+        background-color: var(--light-color);
+    }
+
+    .section-header p,
+    .hero-content p,
+    .page-hero p,
+    .service-card p,
+    .about-text p,
+    .stat p,
+    .contact-item p,
+    .footer-logo p,
+    .footer-links a,
+    .copyright {
+        color: #ccc;
+    }
+
+    .nav-links {
+        background-color: var(--light-color);
+    }
+
+    .form-group input,
+    .form-group textarea {
+        background-color: #343a40;
+        border-color: #495057;
+        color: var(--text-color);
     }
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,6 +9,14 @@
     --transition: all 0.3s ease;
 }
 
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text-color: #f8f9fa;
+        --light-color: #212529;
+        --dark-color: #f8f9fa;
+    }
+}
+
 * {
     margin: 0;
     padding: 0;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,6 +9,47 @@
     --transition: all 0.3s ease;
 }
 
+/* Dark mode variables based on user preference */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --text-color: #f8f9fa;
+        --light-color: #212529;
+        --dark-color: #f8f9fa;
+    }
+
+    body {
+        background-color: var(--light-color);
+    }
+
+    header {
+        background-color: rgba(33, 37, 41, 0.95);
+    }
+
+    header.scrolled {
+        background-color: var(--light-color);
+    }
+
+    .hero,
+    .page-hero {
+        background: linear-gradient(135deg, #343a40 0%, #212529 100%);
+    }
+
+    .services,
+    .service-card,
+    .about,
+    .portfolio,
+    .contact {
+        background-color: var(--light-color);
+    }
+
+    .form-group input,
+    .form-group textarea {
+        background-color: #343a40;
+        border-color: #495057;
+        color: var(--text-color);
+    }
+}
+
 * {
     margin: 0;
     padding: 0;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -12,17 +12,22 @@
 /* Dark mode variables based on user preference */
 @media (prefers-color-scheme: dark) {
     :root {
-        --text-color: #f8f9fa;
+        --text-color: #f1f3f5;
         --light-color: #212529;
-        --dark-color: #f8f9fa;
+        --dark-color: #f1f3f5;
+    }
+
+    html {
+        color-scheme: dark;
     }
 
     body {
+        color: var(--text-color);
         background-color: var(--light-color);
     }
 
     header {
-        background-color: rgba(33, 37, 41, 0.95);
+        background-color: rgba(33,37,41,0.95);
     }
 
     header.scrolled {
@@ -31,7 +36,7 @@
 
     .hero,
     .page-hero {
-        background: linear-gradient(135deg, #343a40 0%, #212529 100%);
+        background: linear-gradient(135deg,#343a40 0%,#212529 100%);
     }
 
     .services,
@@ -39,6 +44,23 @@
     .about,
     .portfolio,
     .contact {
+        background-color: var(--light-color);
+    }
+
+    .section-header p,
+    .hero-content p,
+    .page-hero p,
+    .service-card p,
+    .about-text p,
+    .stat p,
+    .contact-item p,
+    .footer-logo p,
+    .footer-links a,
+    .copyright {
+        color: #ccc;
+    }
+
+    .nav-links {
         background-color: var(--light-color);
     }
 


### PR DESCRIPTION
## Summary
- enable light/dark theming using `prefers-color-scheme` CSS media query
- adjust header, hero, and section backgrounds for dark mode
- document new feature in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_684208fc077c83329c80b3c13fc810f2