### PR TITLE
Add LogoWall hero section

### DIFF
--- a/public/images/logos/ai1.svg
+++ b/public/images/logos/ai1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="10" fill="#4cc9f0"/>
+  <text x="40" y="50" font-size="32" text-anchor="middle" fill="#fff" font-family="Arial">1</text>
+</svg>

--- a/public/images/logos/ai2.svg
+++ b/public/images/logos/ai2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="10" fill="#4361ee"/>
+  <text x="40" y="50" font-size="32" text-anchor="middle" fill="#fff" font-family="Arial">2</text>
+</svg>

--- a/public/images/logos/ai3.svg
+++ b/public/images/logos/ai3.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="10" fill="#3a0ca3"/>
+  <text x="40" y="50" font-size="32" text-anchor="middle" fill="#fff" font-family="Arial">3</text>
+</svg>

--- a/public/images/logos/ai4.svg
+++ b/public/images/logos/ai4.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="10" fill="#f72585"/>
+  <text x="40" y="50" font-size="32" text-anchor="middle" fill="#fff" font-family="Arial">4</text>
+</svg>

--- a/public/images/logos/ai5.svg
+++ b/public/images/logos/ai5.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="10" fill="#ff9e00"/>
+  <text x="40" y="50" font-size="32" text-anchor="middle" fill="#fff" font-family="Arial">5</text>
+</svg>

--- a/public/images/logos/ai6.svg
+++ b/public/images/logos/ai6.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <rect width="80" height="80" rx="10" fill="#8eecf5"/>
+  <text x="40" y="50" font-size="32" text-anchor="middle" fill="#fff" font-family="Arial">6</text>
+</svg>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import Header from "@/components/Header";
 import Hero from "@/components/Hero";
 import Services from "@/components/Services";
+import LogoWall from "@/components/LogoWall";
 import About from "@/components/About";
 import Cta from "@/components/Cta";
 import Contact from "@/components/Contact";
@@ -27,6 +28,7 @@ export default function Home() {
       <Header />
       <Hero />
       <Services />
+      <LogoWall />
       <About />
       <Cta />
       <Contact />

--- a/src/components/LogoWall.tsx
+++ b/src/components/LogoWall.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { animateOnScroll } from "@/utils/animations";
+
+const logos = [
+  "/images/logos/ai1.svg",
+  "/images/logos/ai2.svg",
+  "/images/logos/ai3.svg",
+  "/images/logos/ai4.svg",
+  "/images/logos/ai5.svg",
+  "/images/logos/ai6.svg",
+];
+
+export default function LogoWall() {
+  useEffect(() => {
+    animateOnScroll();
+  }, []);
+
+  return (
+    <section className="logo-wall">
+      <div className="container">
+        <h2 className="animate-on-scroll">Our Favorite AI Tools</h2>
+        <div className="logo-grid">
+          {logos.map((src, index) => (
+            <div key={index} className="logo-item">
+              <img src={src} alt={`AI tool logo ${index + 1}`} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -572,6 +572,46 @@ footer {
     transform: translateY(0);
 }
 
+/* Logo Wall Section */
+.logo-wall {
+    padding: 80px 0;
+    background-color: white;
+    overflow: hidden;
+    text-align: center;
+}
+
+.logo-grid {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 30px;
+    margin-top: 40px;
+}
+
+.logo-item {
+    width: 80px;
+    height: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.logo-item img {
+    width: 80px;
+    height: 80px;
+    animation: move-diagonal 6s linear infinite alternate;
+}
+
+.logo-item:nth-child(2) img { animation-delay: 0.5s; }
+.logo-item:nth-child(3) img { animation-delay: 1s; }
+.logo-item:nth-child(4) img { animation-delay: 1.5s; }
+.logo-item:nth-child(5) img { animation-delay: 2s; }
+.logo-item:nth-child(6) img { animation-delay: 2.5s; }
+@keyframes move-diagonal {
+    0% { transform: translate(0, 0); }
+    100% { transform: translate(30px, -30px); }
+}
+
 /* Responsive Design */
 @media (max-width: 992px) {
     .hero-content h1 {


### PR DESCRIPTION
## Summary
- create new `LogoWall` hero component used as a logo wall
- insert the logo wall in the homepage after the Services section
- add placeholder AI logos and diagonal animation styles

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_6846f3758ae08332bb6be1aaf691943c