### PR TITLE
Add calculator page

### DIFF
--- a/src/app/calculator/page.tsx
+++ b/src/app/calculator/page.tsx
@@ -1,0 +1,18 @@
+import Header from "@/components/Header";
+import Footer from "@/components/Footer";
+import Calculator from "@/components/Calculator";
+
+export const metadata = {
+  title: "Calculator | Obod Soft",
+  description: "Simple calculator inspired by iOS design.",
+};
+
+export default function CalculatorPage() {
+  return (
+    <main>
+      <Header />
+      <Calculator />
+      <Footer />
+    </main>
+  );
+}

--- a/src/components/Calculator.tsx
+++ b/src/components/Calculator.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useState } from "react";
+import "@/styles/calculator.css";
+
+export default function Calculator() {
+  const [display, setDisplay] = useState("0");
+  const [operator, setOperator] = useState<string | null>(null);
+  const [firstValue, setFirstValue] = useState<number | null>(null);
+  const [waitingForSecond, setWaitingForSecond] = useState(false);
+
+  const inputDigit = (digit: string) => {
+    if (waitingForSecond) {
+      setDisplay(digit);
+      setWaitingForSecond(false);
+    } else {
+      setDisplay(display === "0" ? digit : display + digit);
+    }
+  };
+
+  const inputDot = () => {
+    if (waitingForSecond) {
+      setDisplay("0.");
+      setWaitingForSecond(false);
+      return;
+    }
+    if (!display.includes(".")) {
+      setDisplay(display + ".");
+    }
+  };
+
+  const clear = () => {
+    setDisplay("0");
+    setOperator(null);
+    setFirstValue(null);
+    setWaitingForSecond(false);
+  };
+
+  const toggleSign = () => {
+    setDisplay(String(parseFloat(display) * -1));
+  };
+
+  const percent = () => {
+    setDisplay(String(parseFloat(display) / 100));
+  };
+
+  const performOperation = (nextOperator: string) => {
+    const inputValue = parseFloat(display);
+
+    if (firstValue === null) {
+      setFirstValue(inputValue);
+    } else if (operator && !waitingForSecond) {
+      const currentValue = firstValue || 0;
+      let newValue = currentValue;
+
+      switch (operator) {
+        case "+":
+          newValue = currentValue + inputValue;
+          break;
+        case "-":
+          newValue = currentValue - inputValue;
+          break;
+        case "*":
+          newValue = currentValue * inputValue;
+          break;
+        case "/":
+          newValue = currentValue / inputValue;
+          break;
+      }
+      setFirstValue(newValue);
+      setDisplay(String(newValue));
+    }
+
+    setWaitingForSecond(true);
+    setOperator(nextOperator);
+  };
+
+  const handleEquals = () => {
+    if (operator) {
+      performOperation(operator);
+      setOperator(null);
+    }
+  };
+
+  return (
+    <div className="calculator">
+      <div className="display" data-testid="display">{display}</div>
+      <div className="buttons">
+        <button className="function" onClick={clear}>AC</button>
+        <button className="function" onClick={toggleSign}>±</button>
+        <button className="function" onClick={percent}>%</button>
+        <button className="operator" onClick={() => performOperation("/")}>÷</button>
+
+        <button onClick={() => inputDigit("7")}>7</button>
+        <button onClick={() => inputDigit("8")}>8</button>
+        <button onClick={() => inputDigit("9")}>9</button>
+        <button className="operator" onClick={() => performOperation("*")}>×</button>
+
+        <button onClick={() => inputDigit("4")}>4</button>
+        <button onClick={() => inputDigit("5")}>5</button>
+        <button onClick={() => inputDigit("6")}>6</button>
+        <button className="operator" onClick={() => performOperation("-")}>−</button>
+
+        <button onClick={() => inputDigit("1")}>1</button>
+        <button onClick={() => inputDigit("2")}>2</button>
+        <button onClick={() => inputDigit("3")}>3</button>
+        <button className="operator" onClick={() => performOperation("+")}>+</button>
+
+        <button className="zero" onClick={() => inputDigit("0")}>0</button>
+        <button onClick={inputDot}>.</button>
+        <button className="operator" onClick={handleEquals}>=</button>
+      </div>
+    </div>
+  );
+}
+

--- a/src/styles/calculator.css
+++ b/src/styles/calculator.css
@@ -1,0 +1,41 @@
+.calculator {
+  width: 320px;
+  margin: 100px auto;
+  background: #000;
+  border-radius: 20px;
+  padding: 20px;
+  color: #fff;
+  box-shadow: 0 10px 20px rgba(0,0,0,0.25);
+}
+.display {
+  text-align: right;
+  font-size: 3rem;
+  padding: 10px;
+  min-height: 60px;
+}
+.buttons {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+button {
+  font-size: 1.5rem;
+  border: none;
+  border-radius: 50%;
+  padding: 20px;
+  background: #333;
+  color: #fff;
+  cursor: pointer;
+}
+button.function {
+  background: #a5a5a5;
+  color: #000;
+}
+button.operator {
+  background: #f69906;
+  color: #fff;
+}
+button.zero {
+  grid-column: span 2;
+  border-radius: 40px;
+}


### PR DESCRIPTION
## Summary
- create a new Calculator component with an iOS-style UI
- add styles for calculator
- expose calculator at `/calculator` route

## Testing
- `npx next lint` *(fails: Need to install the following packages)*
- `node node_modules/jest/bin/jest.js` *(fails: Cannot find module 'jest-config')*

------
https://chatgpt.com/codex/tasks/task_b_6846f2c1515c833296649eca038cc555