### PR TITLE
Add CV route

### DIFF
--- a/src/app/cv/page.tsx
+++ b/src/app/cv/page.tsx
@@ -1,0 +1,20 @@
+import Header from "@/components/Header";
+import PageHero from "@/components/PageHero";
+import CV from "@/components/CV";
+import Footer from "@/components/Footer";
+
+export const metadata = {
+  title: "CV | Obod Soft",
+  description: "Professional experience and skills of Alex Obodsoft",
+};
+
+export default function CvPage() {
+  return (
+    <main>
+      <Header />
+      <PageHero title="Curriculum Vitae" subtitle="Get to know my professional background" />
+      <CV />
+      <Footer />
+    </main>
+  );
+}

--- a/src/components/CV.tsx
+++ b/src/components/CV.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import { animateOnScroll } from "@/utils/animations";
+
+export default function CV() {
+  useEffect(() => {
+    animateOnScroll();
+  }, []);
+
+  return (
+    <section className="cv">
+      <div className="container">
+        <div className="cv-header animate-on-scroll">
+          <h2>Alex Obodsoft</h2>
+          <p>Full Stack Developer</p>
+        </div>
+        <div className="cv-content">
+          <div className="cv-left animate-on-scroll">
+            <h3>Contact</h3>
+            <p>Email: <a href="mailto:alex@obodsoft.com">alex@obodsoft.com</a></p>
+            <p>Location: Silicon Valley, CA</p>
+
+            <h3>Skills</h3>
+            <ul className="skills">
+              <li>JavaScript & TypeScript</li>
+              <li>React / Next.js</li>
+              <li>Node.js & Express</li>
+              <li>Cloud & DevOps</li>
+            </ul>
+          </div>
+          <div className="cv-right animate-on-scroll">
+            <h3>Experience</h3>
+            <div className="cv-item">
+              <h4>Senior Engineer - Obod Soft</h4>
+              <span>2017 - Present</span>
+              <p>Leading web and mobile projects for clients across the globe.</p>
+            </div>
+            <div className="cv-item">
+              <h4>Software Engineer - Bazaarvoice</h4>
+              <span>2014 - 2017</span>
+              <p>Developed scalable services powering user generated content.</p>
+            </div>
+
+            <h3>Education</h3>
+            <div className="cv-item">
+              <h4>BSc Computer Science</h4>
+              <span>University of Technology</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -54,6 +54,11 @@ export default function Header() {
                 Contact
               </Link>
             </li>
+            <li>
+              <Link href="/cv" onClick={() => setIsMenuOpen(false)}>
+                CV
+              </Link>
+            </li>
           </ul>
           <div className={`hamburger ${isMenuOpen ? "active" : ""}`} onClick={toggleMenu}>
             <span></span>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -512,6 +512,56 @@ nav {
     min-height: 150px;
 }
 
+/* CV Page */
+.cv {
+    background-color: white;
+}
+
+.cv-header {
+    text-align: center;
+    margin-bottom: 40px;
+}
+
+.cv-content {
+    display: flex;
+    gap: 50px;
+}
+
+.cv-left,
+.cv-right {
+    flex: 1;
+}
+
+.cv-left h3,
+.cv-right h3 {
+    color: var(--primary-color);
+    margin-bottom: 15px;
+}
+
+.skills li {
+    margin-bottom: 8px;
+}
+
+.cv-item {
+    margin-bottom: 25px;
+}
+
+.cv-item h4 {
+    font-size: 1.1rem;
+    margin-bottom: 5px;
+}
+
+.cv-item span {
+    font-size: 0.9rem;
+    color: #666;
+}
+
+@media (max-width: 768px) {
+    .cv-content {
+        flex-direction: column;
+    }
+}
+
 /* Footer */
 footer {
     background-color: var(--dark-color);


### PR DESCRIPTION
## Summary
- create new `/cv` route with `CV` page component
- add CV component with contact info, skills and experience
- style new CV page
- link to CV in site navigation

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_6846f2eb1db483328ba52fe8a1e39ed2